### PR TITLE
Updated to newer version of derelict-util

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,7 +6,6 @@
 	"authors": ["Felix Hufnagel"],
 	"targetPath": "bin",
 	"targetType": "library",
-	"version": "0.0.13",
 	"dependencies": {
 		"derelict-util" : ">=3.0.0",
 		"xlib-d": { "version": "~>0.1.1", "optional": true },

--- a/dub.json
+++ b/dub.json
@@ -6,8 +6,9 @@
 	"authors": ["Felix Hufnagel"],
 	"targetPath": "bin",
 	"targetType": "library",
+	"version": "0.0.13",
 	"dependencies": {
-		"derelict-util" : ">=1.0.0",
+		"derelict-util" : ">=3.0.0",
 		"xlib-d": { "version": "~>0.1.1", "optional": true },
 		"xcb-d" : { "version": "~>2.1.0+1.11.1", "optional": true }
 	}


### PR DESCRIPTION
Many other derelict libraries use derelict-util >= 3 now, so I've updated dub.json to use derelict-util >= 3.0.0